### PR TITLE
provider/telegram.go: add header content-type json

### DIFF
--- a/provider/telegram.go
+++ b/provider/telegram.go
@@ -132,6 +132,7 @@ func sendByTelegramApi(reqBody string, t *telegram) error {
 	url := fmt.Sprintf(telegramAPIURL, t.token)
 
 	request, _ := http.NewRequest(http.MethodPost, url, buffer)
+	request.Header.Set("Content-Type", "application/json")
 	response, err := client.Do(request)
 	if err != nil || response.StatusCode > 202 {
 		return err


### PR DESCRIPTION
Fixes Provider Telegram.

Changes proposed in this pull request:
- Add header content-type json provider telegram