### PR TITLE
Add namespace forbid list, to allow all namespaces except certain ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ kubectl apply -f https://raw.githubusercontent.com/abahmed/kwatch/v0.4.0/deploy/
 | Parameter                            | Description                                                                                          |
 |:-------------------------------------|:-----------------------------------------------------------------------------------------------------|
 | `maxRecentLogLines`                  | Optional Max tail log lines in messages, if it's not provided it will get all log lines              |
-| `namespaces`                         | Optional list of namespaces that you want to watch, if it's not provided it will watch all namespaces|
+| `namespaces`                         | Optional comma separated list of namespaces that you want to watch or forbid, if it's not provided it will watch all namespaces. If you want to forbid a namespace, configure it with `!<namespace name>`. You can either set forbidden namespaces or allowed, not both.|
 | `ignoreFailedGracefulShutdown`       | If set to true, containers which are forcefully killed during shutdown (as their graceful shutdown failed) are not reported as error     |
 | `disableUpdateCheck`       | If set to true, does not check for and notify about kwatch updates    |
 

--- a/controller/start.go
+++ b/controller/start.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Start creates an instance of controller after initialization and runs it
-func Start(providers []provider.Provider, ignoreFailedGracefulShutdown bool) {
+func Start(providers []provider.Provider, ignoreFailedGracefulShutdown bool, namespaceAllowList, namespaceForbidList []string) {
 	// create kubernetes client
 	kclient := client.Create()
 
@@ -75,6 +75,9 @@ func Start(providers []provider.Provider, ignoreFailedGracefulShutdown bool) {
 		providers:                    providers,
 		store:                        memory.NewMemory(),
 		ignoreFailedGracefulShutdown: ignoreFailedGracefulShutdown,
+
+		namespaceAllowList:  namespaceAllowList,
+		namespaceForbidList: namespaceForbidList,
 	}
 
 	stopCh := make(chan struct{})


### PR DESCRIPTION
Often you want to watch all but a single namespace (e.g. kube-system). You now can configure that via `!kube-systems` to ignore that certain one.
