### PR TITLE
feat: truncate logs to respect Discord's API requirements

### DIFF
--- a/provider/discord.go
+++ b/provider/discord.go
@@ -92,9 +92,15 @@ func (s *discord) SendEvent(ev *event.Event) error {
 	// add logs part if it exists
 	logs := strings.TrimSpace(ev.Logs)
 	if len(logs) > 0 {
+		logData := logs
+
+		if len(logData) > 1024 {
+			logData = logs[:1024]
+		}
+
 		fields = append(fields, &discordgo.MessageEmbedField{
 			Name:  ":memo: Logs",
-			Value: "```\n" + logs + "```",
+			Value: "```\n" + logData + "```",
 		})
 	}
 


### PR DESCRIPTION
Hello,

I simply tested your project and saw that I got an error 400 because Discord refused the too long content. I made this fix and now it works well. :-)

Thank you for your work.
Have a nice day!