### PR TITLE
:arrow_up: upgrade go version to 1.19

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.18'
+        go-version: '1.19'
 
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ kwatch
 /vendor/
 /Godeps/
 *.DS_Store
+
+# debug
+__debug_bin

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch kwatch",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceRoot}",
+            "showLog": true
+        }
+    ]
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/abahmed/kwatch
 
-go 1.18
+go 1.19
 
 require (
 	github.com/bwmarrin/discordgo v0.25.0


### PR DESCRIPTION
Changes proposed in this pull request:
- Upgrade go version to 1.19
