### PR TITLE
🚀 Allow Slack specify channel in legacy webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ If you want to enable Slack, provide the webhook with optional text and title
 | Parameter                        | Description                                 |
 |:---------------------------------|:------------------------------------------- |
 | `alert.slack.webhook`            | Slack webhook URL                           |
+| `alert.slack.channel`            | Used by legacy webhooks to send messages to specific channel instead of default one |
 | `alert.slack.title`              | Customized title in slack message           |
 | `alert.slack.text`               | Customized text in slack message            |
 

--- a/alertmanager/discord/discord_test.go
+++ b/alertmanager/discord/discord_test.go
@@ -92,7 +92,7 @@ func TestSendEvent(t *testing.T) {
 			"Nam quis nulla. Integer malesuada. In in enim a arcu " +
 			"imperdiet malesuada. Sed vel lectus. Donec odio urna, tempus " +
 			"molestie, porttitor ut, iaculis quis, sem. Phasellus rhoncus.\n",
-		Events: "event1-event2-event3-event1-event2-event3-event1-event2-" +
+		Events: "BackOff Back-off restarting failed container\n" +
 			"event3\nevent5\nevent6-event8-event11-event12",
 	}
 	assert.Nil(c.SendEvent(&ev))

--- a/alertmanager/slack/slack_test.go
+++ b/alertmanager/slack/slack_test.go
@@ -35,6 +35,7 @@ func TestSendMessage(t *testing.T) {
 
 	s := NewSlack(map[string]string{
 		"webhook": "testtest",
+		"channel": "test",
 	})
 	assert.NotNil(s)
 
@@ -57,8 +58,43 @@ func TestSendEvent(t *testing.T) {
 		Container: "test-container",
 		Namespace: "default",
 		Reason:    "OOMKILLED",
-		Logs:      "test\ntestlogs",
-		Events: "event1-event2-event3-event1-event2-event3-event1-event2-" +
+		Logs: "Nam quis nulla. Integer malesuada. In in enim a arcu " +
+			"imperdiet malesuada. Sed vel lectus. Donec odio urna, tempus " +
+			"molestie, porttitor ut, iaculis quis, sem. Phasellus rhoncus.\n" +
+			"Nam quis nulla. Integer malesuada. In in enim a arcu " +
+			"imperdiet malesuada. Sed vel lectus. Donec odio urna, tempus " +
+			"molestie, porttitor ut, iaculis quis, sem. Phasellus rhoncus.\n" +
+			"Nam quis nulla. Integer malesuada. In in enim a arcu " +
+			"imperdiet malesuada. Sed vel lectus. Donec odio urna, tempus " +
+			"molestie, porttitor ut, iaculis quis, sem. Phasellus rhoncus.\n" +
+			"Nam quis nulla. Integer malesuada. In in enim a arcu " +
+			"imperdiet malesuada. Sed vel lectus. Donec odio urna, tempus " +
+			"molestie, porttitor ut, iaculis quis, sem. Phasellus rhoncus.\n" +
+			"Nam quis nulla. Integer malesuada. In in enim a arcu " +
+			"imperdiet malesuada. Sed vel lectus. Donec odio urna, tempus " +
+			"molestie, porttitor ut, iaculis quis, sem. Phasellus rhoncus.\n" +
+			"Nam quis nulla. Integer malesuada. In in enim a arcu " +
+			"imperdiet malesuada. Sed vel lectus. Donec odio urna, tempus " +
+			"molestie, porttitor ut, iaculis quis, sem. Phasellus rhoncus.\n" +
+			"Nam quis nulla. Integer malesuada. In in enim a arcu " +
+			"imperdiet malesuada. Sed vel lectus. Donec odio urna, tempus " +
+			"molestie, porttitor ut, iaculis quis, sem. Phasellus rhoncus.\n" +
+			"Nam quis nulla. Integer malesuada. In in enim a arcu " +
+			"imperdiet malesuada. Sed vel lectus. Donec odio urna, tempus " +
+			"molestie, porttitor ut, iaculis quis, sem. Phasellus rhoncus.\n" +
+			"Nam quis nulla. Integer malesuada. In in enim a arcu " +
+			"imperdiet malesuada. Sed vel lectus. Donec odio urna, tempus " +
+			"molestie, porttitor ut, iaculis quis, sem. Phasellus rhoncus.\n" +
+			"Nam quis nulla. Integer malesuada. In in enim a arcu " +
+			"imperdiet malesuada. Sed vel lectus. Donec odio urna, tempus " +
+			"molestie, porttitor ut, iaculis quis, sem. Phasellus rhoncus.\n" +
+			"Nam quis nulla. Integer malesuada. In in enim a arcu " +
+			"imperdiet malesuada. Sed vel lectus. Donec odio urna, tempus " +
+			"molestie, porttitor ut, iaculis quis, sem. Phasellus rhoncus.\n" +
+			"Nam quis nulla. Integer malesuada. In in enim a arcu " +
+			"imperdiet malesuada. Sed vel lectus. Donec odio urna, tempus " +
+			"molestie, porttitor ut, iaculis quis, sem. Phasellus rhoncus.\n",
+		Events: "BackOff Back-off restarting failed container\n" +
 			"event3\nevent5\nevent6-event8-event11-event12",
 	}
 	assert.Nil(s.SendEvent(&ev))


### PR DESCRIPTION
Fixes #43 

Changes proposed in this pull request:
- Allow slack specify channel in legacy webhooks