### PR TITLE
Ignore pods by pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ kubectl apply -f https://raw.githubusercontent.com/abahmed/kwatch/v0.8.4/deploy/
 | `reasons`                      | Optional comma separated list of reasons that you want to watch or forbid, if it's not provided it will watch all reasons. If you want to forbid a reason, configure it with `!<reason>`. You can either set forbidden reasons or allowed, not both.                     |
 | `ignoreFailedGracefulShutdown` | If set to true, containers which are forcefully killed during shutdown (as their graceful shutdown failed) are not reported as error     |
 | `ignoreContainerNames`         | Optional comma separated list of container names to ignore    |
+| `ignorePodNames`               | Optional list of pod name regexp patterns to ignore    |
 
 ### App
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	"regexp"
+)
+
 type Config struct {
 	// App general configuration
 	App App `yaml:"app"`
@@ -34,6 +38,9 @@ type Config struct {
 	// IgnoreContainerNames optional list of container names to ignore
 	IgnoreContainerNames []string `yaml:"ignoreContainerNames"`
 
+	// IgnorePodNames optional list of pod name regexp patterns to ignore
+	IgnorePodNames []string `yaml:"ignorePodNames"`
+
 	// Alert is a map contains a map of each provider configuration
 	// e.g. {"slack": {"webhook": "URL"}}
 	Alert map[string]map[string]interface{} `yaml:"alert"`
@@ -47,6 +54,9 @@ type Config struct {
 	// Reasons configuration
 	AllowedReasons   []string
 	ForbiddenReasons []string
+
+	// Patterns are compiled from IgnorePodNames after loading
+	IgnorePodNamePatterns []*regexp.Regexp
 }
 
 // App confing struct

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -97,3 +97,24 @@ func TestConfigFromFile(t *testing.T) {
 	_, err := LoadConfig()
 	assert.NotNil(err)
 }
+
+func TestGetCompiledIgnorePodNamePatterns(t *testing.T) {
+	assert := assert.New(t)
+
+	validPatterns := []string{
+		"my-fancy-pod-[0-9]",
+	}
+
+	compiledPatterns, err := getCompiledIgnorePodNamePatterns(validPatterns)
+
+	assert.Nil(err)
+	assert.True(compiledPatterns[0].MatchString("my-fancy-pod-8"))
+
+	invalidPatterns := []string{
+		"my-fancy-pod-[.*",
+	}
+
+	compiledPatterns, err = getCompiledIgnorePodNamePatterns(invalidPatterns)
+
+	assert.NotNil(err)
+}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -214,9 +214,20 @@ func (c *Controller) processPod(key string, pod *v1.Pod) {
 		if len(c.config.IgnoreContainerNames) > 0 &&
 			slices.Contains(c.config.IgnoreContainerNames, container.Name) {
 			logrus.Infof(
-				"skip pod %s as in container ignore list",
+				"skip container %s as in container ignore list",
 				container.Name)
 			return
+		}
+
+		if len(c.config.IgnorePodNames) > 0 {
+			for _, pattern := range c.config.IgnorePodNamePatterns {
+				if pattern.MatchString(pod.Name) {
+					logrus.Infof(
+						"skip pod %s as in pod name patterns ignore list",
+						container.Name)
+					return
+				}
+			}
 		}
 
 		// get logs for this container


### PR DESCRIPTION
Add a config option to ignore events by pods matching a regex pattern

Fixes #240 

Changes proposed in this pull request:
- Add a new config option `ignorePodNames`. This takes a list of regex patterns which can be used to ignore events from pods matching one of the patterns.
