### PR TITLE
restart pods when config map changes

### DIFF
--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kwatch
-version: "0.9.6"
-appVersion: "v0.9.6"
+version: "0.9.5"
+appVersion: "v0.9.5"
 description: monitor all changes in your Kubernetes(K8s) cluster, detects crashes
   in your running apps in realtime, and publishes notifications to your channels (Slack,
   Discord, etc.) instantly

--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kwatch
-version: "0.9.5"
-appVersion: "v0.9.5"
+version: "0.9.6"
+appVersion: "v0.9.6"
 description: monitor all changes in your Kubernetes(K8s) cluster, detects crashes
   in your running apps in realtime, and publishes notifications to your channels (Slack,
   Discord, etc.) instantly

--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -27,6 +27,7 @@ helm delete --purge [RELEASE_NAME]
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `podAnnotations` | Pod annotations | {} |
+| `podLabels` | Pod labels | {} |
 | `securityContext.runAsNonRoot` | Container runs as a non-root user | true |
 | `securityContext.runAsUser` | Container processes' UID to run the entrypoint | 101 |
 | `securityContext.runAsGroup` | Container processes' GID to run the entrypoint | 101 |

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -12,10 +12,11 @@ spec:
       {{- include "kwatch.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "kwatch.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}


### PR DESCRIPTION
The chart as it is currently will not redeploy the pods when the config changes. This adds that functionality as recommended by helm here https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments

also added in documentation for podLabels from my previous pr that I forgot.

Should I increment chart versions?

Working template output

![image](https://github.com/user-attachments/assets/12938559-3aa8-4e95-9f60-5ab7c86f9c82)
