### PR TITLE
update value descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ kubectl apply -f https://raw.githubusercontent.com/abahmed/kwatch/v0.10.0/deploy
 | Parameter                      | Description   |
 |:-------------------------------|:-----------------------|
 | `maxRecentLogLines`            | Optional Max tail log lines in messages, if it's not provided it will get all log lines |
-| `namespaces`                   | Optional comma separated list of namespaces that you want to watch or forbid, if it's not provided it will watch all namespaces. If you want to forbid a namespace, configure it with `!<namespace name>`. You can either set forbidden namespaces or allowed, not both. |
-| `reasons`                      | Optional comma separated list of reasons that you want to watch or forbid, if it's not provided it will watch all reasons. If you want to forbid a reason, configure it with `!<reason>`. You can either set forbidden reasons or allowed, not both.                     |
+| `namespaces`                   | Optional list of namespaces that you want to watch or forbid, if it's not provided it will watch all namespaces. If you want to forbid a namespace, configure it with `!<namespace name>`. You can either set forbidden namespaces or allowed, not both. |
+| `reasons`                      | Optional list of reasons that you want to watch or forbid, if it's not provided it will watch all reasons. If you want to forbid a reason, configure it with `!<reason>`. You can either set forbidden reasons or allowed, not both.                     |
 | `ignoreFailedGracefulShutdown` | If set to true, containers which are forcefully killed during shutdown (as their graceful shutdown failed) are not reported as error     |
-| `ignoreContainerNames`         | Optional comma separated list of container names to ignore    |
+| `ignoreContainerNames`         | Optional list of container names to ignore    |
 | `ignorePodNames`               | Optional list of pod name regexp patterns to ignore    |
 | `IgnoreLogPatterns`            | Optional list of regexp patterns of logs to ignore     |
 


### PR DESCRIPTION
Fixes # .

I'm not entirely sure if this is correct, but inspecting the objects between the ones that ask for a list and a comma separated list on the golang side they look to be the same. i seem to be able to define yaml lists for these as well and they work vs comma separated strings.

this cleans up the documentation to make these variables more clear.
