### PR TITLE
Migrated notifications from webhook to power automate 

### DIFF
--- a/alertmanager/teams/teams.go
+++ b/alertmanager/teams/teams.go
@@ -1,211 +1,214 @@
 package teams
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"io"
-	"strings"
-	"time"
-	"net/http"
+    "bytes"
+    "encoding/json"
+    "fmt"
+    "io"
+    "net/http"
+    "strings"
+    "time"
 
-	"github.com/abahmed/kwatch/config"
-	"github.com/abahmed/kwatch/event"
-	"github.com/sirupsen/logrus"
+    "github.com/abahmed/kwatch/config"
+    "github.com/abahmed/kwatch/event"
+    "github.com/sirupsen/logrus"
 )
 
 const (
-	defaultTeamsTitle = "&#9937; Kwatch detected a crash in pod"
+    defaultTeamsTitle = "&#9937; Kwatch detected a crash in pod"
 )
 
 type Teams struct {
-	// The HTTP trigger URL for the Power Automate flow
-	flowUrl string
-	title   string
-	text    string
+    // The HTTP trigger URL for the Power Automate flow
+    flowURL string
+    title   string
+    text    string
 
-	// reference for general app configuration
-	appCfg *config.App
+    // reference for general app configuration
+    appCfg *config.App
 }
 
 type teamsFlowPayload struct {
-	Title string `json:"title"`
-	Text  string `json:"text"`
-	Attachment []map[string]interface{} `json:"attachment"`
+    Title      string                   `json:"title"`
+    Text       string                   `json:"text"`
+    Attachment []map[string]interface{} `json:"attachment"`
 }
 
 // NewTeams returns new team instance
 func NewTeams(config map[string]interface{}, appCfg *config.App) *Teams {
-	flowURL, ok := config["flowURL"].(string)
-	if !ok || len(flowURL) == 0 {
-		logrus.Warnf("initializing Teams with empty flow url")
-		return nil
-	}
+    flowURL, ok := config["flowURL"].(string)
+    if !ok || len(flowURL) == 0 {
+        logrus.Warnf("initializing Teams with empty flow url")
+        return nil
+    }
 
-	logrus.Infof("initializing Teams with flow url: %s", flowURL)
+    logrus.Infof("initializing Teams with flow url: %s", flowURL)
 
-	title, _ := config["title"].(string)
-	text, _ := config["text"].(string)
+    title, _ := config["title"].(string)
+    text, _ := config["text"].(string)
 
-	return &Teams{
-		flowURL: flowURL,
-		title:   title,
-		text:    text,
-		appCfg:  appCfg,
-	}
+    return &Teams{
+        flowURL: flowURL,
+        title:   title,
+        text:    text,
+        appCfg:  appCfg,
+    }
 }
 
 // Name returns name of the provider
 func (t *Teams) Name() string {
-	return "Microsoft Teams"
+    return "Microsoft Teams"
 }
 
 // SendEvent sends event to the Power Automate flow
 func (t *Teams) SendEvent(e *event.Event) error {
-	payload := t.buildRequestBodyTeams(e)
-	return t.sendAPI(payload)
+    payload := t.buildRequestBodyTeams(e)
+    return t.sendAPI(payload)
 }
 
 // SendMessage sends plain text message to the Power Automate flow
 func (t *Teams) SendMessage(msg string) error {
-	payload := t.buildRequestBodyMessage(msg)
-	return t.sendAPI(payload)
+    payload := t.buildRequestBodyMessage(msg)
+    return t.sendAPI(payload)
 }
 
 // SendApi send the given payload to the Power Automate flow with retry logic
 func (t *Teams) sendAPI(payload []byte) error {
-	// Number of retry attempts
-	maxRetries := 3
-	retryDelay := 5 * time.Second
+    // Number of retry attempts
+    maxRetries := 3
+    retryDelay := 5 * time.Second
 
-	// try to send the message up to "maxretries" times
-	for attemps := 0; attemps < maxRetries; attemps++ {
-		request, err := http.NewRequest(http.MethodPost, t.flowURL, bytes.NewBuffer(payload))
-		if err != nil {
-			return fmt.Errorf("error creating HTTP request: %v", err)
-		}
+    // try to send the message up to "maxRetries" times
+    for attempts := 0; attempts < maxRetries; attempts++ {
+        request, err := http.NewRequest(http.MethodPost, t.flowURL, bytes.NewBuffer(payload))
+        if err != nil {
+            return fmt.Errorf("error creating HTTP request: %v", err)
+        }
 
-		request.Header.Set("Content-Type", "application/json")
+        request.Header.Set("Content-Type", "application/json")
 
-		client := &http.Client{}
-		resp, err := client.Do(request)
-		if err != nil {
-			return fmt.Errorf("failed to create HTTP response: %w", err)
-		}
-		defer resp.Body.Close()
+        client := &http.Client{}
+        resp, err := client.Do(request)
+        if err != nil {
+            return fmt.Errorf("failed to create HTTP response: %w", err)
+        }
+        defer resp.Body.Close()
 
-		//Check for success (HTTP 200 OK)
-		if resp.StatusCode == http.StatusOK {
-			return nil
-			// Message successfully sent		
-		}
+        // Check for success (HTTP 200 OK)
+        if resp.StatusCode == http.StatusOK {
+            return nil
+        }
 
-		//Handle specific 400 errors (TriggerInputSchemaMismatch)
-		if resp.StatusCode == http.StatusBadRequest {
-			body, _ := io.ReadAll(response.Body)
-			//Check for error (TriggerInputSchemaMismatch)
-			if strings.Contains(string(body), "TriggerInputSchemaMismatch") {
-				return fmt.Errorf("failed to send message due to schema mismatch: %s", string(body))
-			}
-			return fmt.Errorf("call to power automate flow returned status %d: %s", resp.StatusCode, string(body))
-		}
+        // Handle specific 400 errors (TriggerInputSchemaMismatch)
+        if resp.StatusCode == http.StatusBadRequest {
+            body, _ := io.ReadAll(resp.Body)
+            // Check for error (TriggerInputSchemaMismatch)
+            if strings.Contains(string(body), "TriggerInputSchemaMismatch") {
+                return fmt.Errorf("failed to send message due to schema mismatch: %s", string(body))
+            }
+            return fmt.Errorf("call to power automate flow returned status %d: %s", resp.StatusCode, string(body))
+        }
 
-		//Handle 202 status and retry
-		if response.StatusCode == http.StatusAccepted {
-			logrus.Warnf("Request accepted by Power Automate flow, but not processed immediately.Attempt %d of %d.", attempts+1, maxRetries)
-		}
-		else {
-			// For other non-200 status codes, log the error
-			body, _ := io.ReadAll(resp.Body)
-			return fmt.Errorf("call to power automate flow returned status %d: %s", resp.StatusCode, string(body))
-		}
+        // Handle 202 status and retry
+        if resp.StatusCode == http.StatusAccepted {
+            logrus.Warnf("Request accepted by Power Automate flow, but not processed immediately. Attempt %d of %d.", attempts+1, maxRetries)
+        } else {
+            // For other non-200 status codes, log the error
+            body, _ := io.ReadAll(resp.Body)
+            return fmt.Errorf("call to power automate flow returned status %d: %s", resp.StatusCode, string(body))
+        }
 
-		//Wait for a delay before retrying
-		if attempts < maxRetries-1 {
-			time.Sleep(retryDelay)
-		}
-	}
+        // Wait for a delay before retrying
+        if attempts < maxRetries-1 {
+            time.Sleep(retryDelay)
+        }
+    }
 
-	//After all retries, return an error
-	return fmt .Errorf("failed to send message after %d attempts", maxRetries)
+    // After all retries, return an error
+    return fmt.Errorf("failed to send message after %d attempts", maxRetries)
 }
 
-//buildRequestBodyTeams builds the request body for the Power Automate flow
+// buildRequestBodyTeams builds the request body for the Power Automate flow
 func (t *Teams) buildRequestBodyTeams(e *event.Event) []byte {
-	// Use custom title if its provided, otherwise use the default title
-	title := t.title
-	if len(title) == 0 {
-		title = defaultTeamsTitle
-	}
+    // Use custom title if it's provided, otherwise use the default title
+    title := t.title
+    if len(title) == 0 {
+        title = defaultTeamsTitle
+    }
 
-	//format the message with markdown
-	msg : = e.FormatMarkdown(t.appCfg.ClusterName, t.text, "\n\n")
+    // Format the message with markdown
+    msg := e.FormatMarkdown(t.appCfg.ClusterName, t.text, "\n\n")
 
-	// Create the attachment for the message with full event details
-	attachments := []map[string]interface{}{
-		{
-			"contentType": "application/vnd.microsoft.card.adaptive",
-			"content": map[string]interface{}{
-				"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-				"type": "AdaptiveCard",
-				"version": "1.2",
-				"body": []map[string]interface{}{
-					{
-						"type": "TextBlock",
-						"text": title,
-					},
-					{
-						"type": "TextBlock",
-						"text": fmt.Sprintf("Pod Name: %s", e.PodName),
-					},
-					{
-						"type": "TextBlock",
-						"text": fmt.Sprintf("Namespace: %s", e.Namespace),
-					},
-					{	
-						"type": "TextBlock",
-						"text": fmt.Sprintf("Reason: %s", e.Reason),
-					},
-					{
-						"type": "TextBlock",
-						"text": fmt.Sprintf("Logs: %s", e.Logs),
-					},
-					{
-						"type": "TextBlock",
-						"text": fmt.Sprintf("Events: \n%s", e.Events),
-					},
-					{
-						"type": "TextBlock",
-						"text": fmt.Sprintf("Time: %s", time.now().Format(time.RFC1123Format)),
-					},	
+    // Create the attachment for the message with full event details
+    attachments := []map[string]interface{}{
+        {
+            "contentType": "application/vnd.microsoft.card.adaptive",
+            "content": map[string]interface{}{
+                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                "type":    "AdaptiveCard",
+                "version": "1.2",
+                "body": []map[string]interface{}{
+                    {
+                        "type": "TextBlock",
+                        "text": title,
+                    },
+                    {
+                        "type": "TextBlock",
+                        "text": fmt.Sprintf("Pod Name: %s", e.PodName),
+                    },
+                    {
+                        "type": "TextBlock",
+                        "text": fmt.Sprintf("Namespace: %s", e.Namespace),
+                    },
+                    {
+                        "type": "TextBlock",
+                        "text": fmt.Sprintf("Reason: %s", e.Reason),
+                    },
+                    {
+                        "type": "TextBlock",
+                        "text": fmt.Sprintf("Logs: %s", e.Logs),
+                    },
+                    {
+                        "type": "TextBlock",
+                        "text": fmt.Sprintf("Events: \n%s", e.Events),
+                    },
+                    {
+                        "type": "TextBlock",
+                        "text": fmt.Sprintf("Time: %s", time.Now().Format(time.RFC1123)),
+                    },
+                },
+            },
+        },
+    }
 
-				},
-			},
-		},
-	}
+    // Prepare the payload for the Power Automate flow
+    payload := &teamsFlowPayload{
+        Title:      title,
+        Text:       msg,
+        Attachment: attachments, // Attachment should be an array
+    }
 
-	//Prepare the payload for the Power Automate flow
-	payload := &teamsFlowPayload{
-		Title: title,
-		Text:  msg,
-		Attachment: attachments, // Attachment should be an array
-	}
-
-	jsonBytes, _ := json.Marshal(payload)
-	return jsonBytes
+    jsonBytes, err := json.Marshal(payload)
+    if err != nil {
+        logrus.Errorf("failed to marshal payload: %v", err)
+        return nil
+    }
+    return jsonBytes
 }
 
-//buildRequestBodyMessage builds plain message payload for the Power Automate flow
+// buildRequestBodyMessage builds plain message payload for the Power Automate flow
 func (t *Teams) buildRequestBodyMessage(msg string) []byte {
-	payload := &teamsFlowPayload{
-		Title: "New Alert",
-		Text:  msg,
-	    // Empty attachments array to prevent schema mismatch error
-		Attachment: []map[string]interface{}{},
-	}
+    payload := &teamsFlowPayload{
+        Title: "New Alert",
+        Text:  msg,
+        // Empty attachments array to prevent schema mismatch error
+        Attachment: []map[string]interface{}{},
+    }
 
-	jsonBytes, _ := json.Marshal(payload)
-	return jsonBytes
+    jsonBytes, err := json.Marshal(payload)
+    if err != nil {
+        logrus.Errorf("failed to marshal payload: %v", err)
+        return nil
+    }
+    return jsonBytes
 }
-
-

--- a/alertmanager/teams/teams.go
+++ b/alertmanager/teams/teams.go
@@ -19,7 +19,7 @@ const (
 )
 
 type Teams struct {
-	# The HTTP trigger URL for the Power Automate flow
+	// The HTTP trigger URL for the Power Automate flow
 	flowUrl string
 	title   string
 	text    string

--- a/alertmanager/teams/teams.go
+++ b/alertmanager/teams/teams.go
@@ -5,7 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-
+	"strings"
+	"time"
 	"net/http"
 
 	"github.com/abahmed/kwatch/config"
@@ -18,7 +19,8 @@ const (
 )
 
 type Teams struct {
-	webhook string
+	# The HTTP trigger URL for the Power Automate flow
+	flowUrl string
 	title   string
 	text    string
 
@@ -26,26 +28,27 @@ type Teams struct {
 	appCfg *config.App
 }
 
-type teamsWebhookPayload struct {
+type teamsFlowPayload struct {
 	Title string `json:"title"`
 	Text  string `json:"text"`
+	Attachment []map[string]interface{} `json:"attachment"`
 }
 
 // NewTeams returns new team instance
 func NewTeams(config map[string]interface{}, appCfg *config.App) *Teams {
-	webhook, ok := config["webhook"].(string)
-	if !ok || len(webhook) == 0 {
-		logrus.Warnf("initializing Teams with empty webhook url")
+	flowURL, ok := config["flowURL"].(string)
+	if !ok || len(flowURL) == 0 {
+		logrus.Warnf("initializing Teams with empty flow url")
 		return nil
 	}
 
-	logrus.Infof("initializing Teams with webhook url: %s", webhook)
+	logrus.Infof("initializing Teams with flow url: %s", flowURL)
 
 	title, _ := config["title"].(string)
 	text, _ := config["text"].(string)
 
 	return &Teams{
-		webhook: webhook,
+		flowURL: flowURL,
 		title:   title,
 		text:    text,
 		appCfg:  appCfg,
@@ -57,63 +60,152 @@ func (t *Teams) Name() string {
 	return "Microsoft Teams"
 }
 
-// SendEvent sends event to the provider
+// SendEvent sends event to the Power Automate flow
 func (t *Teams) SendEvent(e *event.Event) error {
-	return t.sendAPI(t.buildRequestBodyTeams(e))
+	payload := t.buildRequestBodyTeams(e)
+	return t.sendAPI(payload)
 }
 
-// SendMessage sends text message to the provider
+// SendMessage sends plain text message to the Power Automate flow
 func (t *Teams) SendMessage(msg string) error {
-
-	msgPayload := &teamsWebhookPayload{
-		Text: msg,
-	}
-
-	jsonBytes, _ := json.Marshal(msgPayload)
-	return t.sendAPI(jsonBytes)
+	payload := t.buildRequestBodyMessage(msg)
+	return t.sendAPI(payload)
 }
 
-func (t *Teams) sendAPI(b []byte) error {
-	buffer := bytes.NewBuffer(b)
-	request, err := http.NewRequest(http.MethodPost, t.webhook, buffer)
-	if err != nil {
-		return err
+// SendApi send the given payload to the Power Automate flow with retry logic
+func (t *Teams) sendAPI(payload []byte) error {
+	// Number of retry attempts
+	maxRetries := 3
+	retryDelay := 5 * time.Second
+
+	// try to send the message up to "maxretries" times
+	for attemps := 0; attemps < maxRetries; attemps++ {
+		request, err := http.NewRequest(http.MethodPost, t.flowURL, bytes.NewBuffer(payload))
+		if err != nil {
+			return fmt.Errorf("error creating HTTP request: %v", err)
+		}
+
+		request.Header.Set("Content-Type", "application/json")
+
+		client := &http.Client{}
+		resp, err := client.Do(request)
+		if err != nil {
+			return fmt.Errorf("failed to create HTTP response: %w", err)
+		}
+		defer resp.Body.Close()
+
+		//Check for success (HTTP 200 OK)
+		if resp.StatusCode == http.StatusOK {
+			return nil
+			// Message successfully sent		
+		}
+
+		//Handle specific 400 errors (TriggerInputSchemaMismatch)
+		if resp.StatusCode == http.StatusBadRequest {
+			body, _ := io.ReadAll(response.Body)
+			//Check for error (TriggerInputSchemaMismatch)
+			if strings.Contains(string(body), "TriggerInputSchemaMismatch") {
+				return fmt.Errorf("failed to send message due to schema mismatch: %s", string(body))
+			}
+			return fmt.Errorf("call to power automate flow returned status %d: %s", resp.StatusCode, string(body))
+		}
+
+		//Handle 202 status and retry
+		if response.StatusCode == http.StatusAccepted {
+			logrus.Warnf("Request accepted by Power Automate flow, but not processed immediately.Attempt %d of %d.", attempts+1, maxRetries)
+		}
+		else {
+			// For other non-200 status codes, log the error
+			body, _ := io.ReadAll(resp.Body)
+			return fmt.Errorf("call to power automate flow returned status %d: %s", resp.StatusCode, string(body))
+		}
+
+		//Wait for a delay before retrying
+		if attempts < maxRetries-1 {
+			time.Sleep(retryDelay)
+		}
 	}
 
-	request.Header.Set("Content-Type", "application/json")
-
-	client := &http.Client{}
-	response, err := client.Do(request)
-	if err != nil {
-		return err
-	}
-	defer response.Body.Close()
-
-	if response.StatusCode != 200 {
-		body, _ := io.ReadAll(response.Body)
-		return fmt.Errorf(
-			"call to teams alert returned status code %d: %s",
-			response.StatusCode,
-			string(body))
-	}
-
-	return nil
+	//After all retries, return an error
+	return fmt .Errorf("failed to send message after %d attempts", maxRetries)
 }
 
-// buildRequestBodyTeams builds formatted string from event
+//buildRequestBodyTeams builds the request body for the Power Automate flow
 func (t *Teams) buildRequestBodyTeams(e *event.Event) []byte {
-	// use custom title if it's provided, otherwise use default
+	// Use custom title if its provided, otherwise use the default title
 	title := t.title
 	if len(title) == 0 {
 		title = defaultTeamsTitle
 	}
 
-	msg := e.FormatMarkdown(t.appCfg.ClusterName, t.text, "\n\n")
-	msgPayload := &teamsWebhookPayload{
-		Title: title,
-		Text:  msg,
+	//format the message with markdown
+	msg : = e.FormatMarkdown(t.appCfg.ClusterName, t.text, "\n\n")
+
+	// Create the attachment for the message with full event details
+	attachments := []map[string]interface{}{
+		{
+			"contentType": "application/vnd.microsoft.card.adaptive",
+			"content": map[string]interface{}{
+				"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+				"type": "AdaptiveCard",
+				"version": "1.2",
+				"body": []map[string]interface{}{
+					{
+						"type": "TextBlock",
+						"text": title,
+					},
+					{
+						"type": "TextBlock",
+						"text": fmt.Sprintf("Pod Name: %s", e.PodName),
+					},
+					{
+						"type": "TextBlock",
+						"text": fmt.Sprintf("Namespace: %s", e.Namespace),
+					},
+					{	
+						"type": "TextBlock",
+						"text": fmt.Sprintf("Reason: %s", e.Reason),
+					},
+					{
+						"type": "TextBlock",
+						"text": fmt.Sprintf("Logs: %s", e.Logs),
+					},
+					{
+						"type": "TextBlock",
+						"text": fmt.Sprintf("Events: \n%s", e.Events),
+					},
+					{
+						"type": "TextBlock",
+						"text": fmt.Sprintf("Time: %s", time.now().Format(time.RFC1123Format)),
+					},	
+
+				},
+			},
+		},
 	}
 
-	jsonBytes, _ := json.Marshal(msgPayload)
-	return (jsonBytes)
+	//Prepare the payload for the Power Automate flow
+	payload := &teamsFlowPayload{
+		Title: title,
+		Text:  msg,
+		Attachment: attachments, // Attachment should be an array
+	}
+
+	jsonBytes, _ := json.Marshal(payload)
+	return jsonBytes
 }
+
+//buildRequestBodyMessage builds plain message payload for the Power Automate flow
+func (t *Teams) buildRequestBodyMessage(msg string) []byte {
+	payload := &teamsFlowPayload{
+		Title: "New Alert",
+		Text:  msg,
+	    // Empty attachments array to prevent schema mismatch error
+		Attachment: []map[string]interface{}{},
+	}
+
+	jsonBytes, _ := json.Marshal(payload)
+	return jsonBytes
+}
+
+

--- a/alertmanager/teams/teams_test.go
+++ b/alertmanager/teams/teams_test.go
@@ -8,6 +8,7 @@ import (
 
     "github.com/abahmed/kwatch/event"
     "github.com/stretchr/testify/assert"
+	"github.com/stretchr/kwatch/config"
 )
 
 func TestNewTeams(t *testing.T) {
@@ -16,8 +17,7 @@ func TestNewTeams(t *testing.T) {
         "title":   "Test Title",
         "text":    "Test Text",
     }
-    appCfg := &struct{}{} // Use an empty struct for appCfg
-
+    appCfg := &config.App{}
     teams := NewTeams(config, appCfg)
     assert.NotNil(t, teams)
     assert.Equal(t, "http://example.com", teams.flowURL)
@@ -29,7 +29,7 @@ func TestSendEvent(t *testing.T) {
     config := map[string]interface{}{
         "flowURL": "http://example.com",
     }
-    appCfg := &struct{}{} // Use an empty struct for appCfg
+    appCfg := &config.App{}
     teams := NewTeams(config, appCfg)
 
     e := &event.Event{
@@ -54,7 +54,7 @@ func TestSendMessage(t *testing.T) {
     config := map[string]interface{}{
         "flowURL": "http://example.com",
     }
-    appCfg := &struct{}{} // Use an empty struct for appCfg
+    appCfg := &config.App{}
     teams := NewTeams(config, appCfg)
 
     server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -71,7 +71,7 @@ func TestSendAPI(t *testing.T) {
     config := map[string]interface{}{
         "flowURL": "http://example.com",
     }
-    appCfg := &struct{}{} // Use an empty struct for appCfg
+    appCfg := &config.App{}
     teams := NewTeams(config, appCfg)
 
     payload := []byte(`{"title":"Test Title","text":"Test Text","attachment":[]}`)
@@ -92,7 +92,7 @@ func TestBuildRequestBodyTeams(t *testing.T) {
         "title":   "Test Title",
         "text":    "Test Text",
     }
-    appCfg := &struct{}{} // Use an empty struct for appCfg
+    appCfg := &config.App{}
     teams := NewTeams(config, appCfg)
 
     e := &event.Event{
@@ -119,7 +119,7 @@ func TestBuildRequestBodyMessage(t *testing.T) {
     config := map[string]interface{}{
         "flowURL": "http://example.com",
     }
-    appCfg := &struct{}{} // Use an empty struct for appCfg
+    appCfg := &config.App{}
     teams := NewTeams(config, appCfg)
 
     payload := teams.buildRequestBodyMessage("test message")

--- a/alertmanager/teams/teams_test.go
+++ b/alertmanager/teams/teams_test.go
@@ -6,7 +6,6 @@ import (
     "net/http/httptest"
     "testing"
 
-    "github.com/abahmed/kwatch/config"
     "github.com/abahmed/kwatch/event"
     "github.com/stretchr/testify/assert"
 )
@@ -17,7 +16,7 @@ func TestNewTeams(t *testing.T) {
         "title":   "Test Title",
         "text":    "Test Text",
     }
-    appCfg := &config.App{}
+    appCfg := &struct{}{} // Use an empty struct for appCfg
 
     teams := NewTeams(config, appCfg)
     assert.NotNil(t, teams)
@@ -30,7 +29,7 @@ func TestSendEvent(t *testing.T) {
     config := map[string]interface{}{
         "flowURL": "http://example.com",
     }
-    appCfg := &config.App{}
+    appCfg := &struct{}{} // Use an empty struct for appCfg
     teams := NewTeams(config, appCfg)
 
     e := &event.Event{
@@ -55,7 +54,7 @@ func TestSendMessage(t *testing.T) {
     config := map[string]interface{}{
         "flowURL": "http://example.com",
     }
-    appCfg := &config.App{}
+    appCfg := &struct{}{} // Use an empty struct for appCfg
     teams := NewTeams(config, appCfg)
 
     server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -72,7 +71,7 @@ func TestSendAPI(t *testing.T) {
     config := map[string]interface{}{
         "flowURL": "http://example.com",
     }
-    appCfg := &config.App{}
+    appCfg := &struct{}{} // Use an empty struct for appCfg
     teams := NewTeams(config, appCfg)
 
     payload := []byte(`{"title":"Test Title","text":"Test Text","attachment":[]}`)
@@ -93,7 +92,7 @@ func TestBuildRequestBodyTeams(t *testing.T) {
         "title":   "Test Title",
         "text":    "Test Text",
     }
-    appCfg := &config.App{}
+    appCfg := &struct{}{} // Use an empty struct for appCfg
     teams := NewTeams(config, appCfg)
 
     e := &event.Event{
@@ -120,7 +119,7 @@ func TestBuildRequestBodyMessage(t *testing.T) {
     config := map[string]interface{}{
         "flowURL": "http://example.com",
     }
-    appCfg := &config.App{}
+    appCfg := &struct{}{} // Use an empty struct for appCfg
     teams := NewTeams(config, appCfg)
 
     payload := teams.buildRequestBodyMessage("test message")

--- a/alertmanager/teams/teams_test.go
+++ b/alertmanager/teams/teams_test.go
@@ -1,7 +1,6 @@
 package teams
 
 import (
-    "bytes"
     "encoding/json"
     "net/http"
     "net/http/httptest"

--- a/alertmanager/teams/teams_test.go
+++ b/alertmanager/teams/teams_test.go
@@ -1,116 +1,134 @@
 package teams
 
 import (
-	"net/http"
-	"net/http/httptest"
-	"testing"
+    "bytes"
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "testing"
 
-	"github.com/abahmed/kwatch/config"
-	"github.com/abahmed/kwatch/event"
-	"github.com/stretchr/testify/assert"
+    "github.com/abahmed/kwatch/config"
+    "github.com/abahmed/kwatch/event"
+    "github.com/stretchr/testify/assert"
 )
 
-func TestEmptyConfig(t *testing.T) {
-	assert := assert.New(t)
+func TestNewTeams(t *testing.T) {
+    config := map[string]interface{}{
+        "flowURL": "http://example.com",
+        "title":   "Test Title",
+        "text":    "Test Text",
+    }
+    appCfg := &config.App{}
 
-	c := NewTeams(map[string]interface{}{}, &config.App{ClusterName: "dev"})
-	assert.Nil(c)
-}
-
-func TestTeams(t *testing.T) {
-	assert := assert.New(t)
-
-	configMap := map[string]interface{}{
-		"webhook": "testtest",
-	}
-	c := NewTeams(configMap, &config.App{ClusterName: "dev"})
-	assert.NotNil(c)
-
-	assert.Equal(c.Name(), "Microsoft Teams")
-}
-
-func TestSendMessage(t *testing.T) {
-	assert := assert.New(t)
-
-	s := httptest.NewServer(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Write([]byte(`{"isOk": true}`))
-		}))
-
-	defer s.Close()
-
-	configMap := map[string]interface{}{
-		"webhook": s.URL,
-	}
-	c := NewTeams(configMap, &config.App{ClusterName: "dev"})
-	assert.NotNil(c)
-
-	assert.Nil(c.SendMessage("test"))
-}
-
-func TestSendMessageError(t *testing.T) {
-	assert := assert.New(t)
-
-	s := httptest.NewServer(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusBadGateway)
-		}))
-
-	defer s.Close()
-
-	configMap := map[string]interface{}{
-		"webhook": s.URL,
-	}
-	c := NewTeams(configMap, &config.App{ClusterName: "dev"})
-	assert.NotNil(c)
-
-	assert.NotNil(c.SendMessage("test"))
+    teams := NewTeams(config, appCfg)
+    assert.NotNil(t, teams)
+    assert.Equal(t, "http://example.com", teams.flowURL)
+    assert.Equal(t, "Test Title", teams.title)
+    assert.Equal(t, "Test Text", teams.text)
 }
 
 func TestSendEvent(t *testing.T) {
-	assert := assert.New(t)
+    config := map[string]interface{}{
+        "flowURL": "http://example.com",
+    }
+    appCfg := &config.App{}
+    teams := NewTeams(config, appCfg)
 
-	s := httptest.NewServer(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Write([]byte(`{"isOk": true}`))
-		}))
+    e := &event.Event{
+        PodName:   "test-pod",
+        Namespace: "test-namespace",
+        Reason:    "test-reason",
+        Logs:      "test-logs",
+        Events:    "test-events",
+    }
 
-	defer s.Close()
+    server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.WriteHeader(http.StatusOK)
+    }))
+    defer server.Close()
 
-	configMap := map[string]interface{}{
-		"webhook": s.URL,
-	}
-	c := NewTeams(configMap, &config.App{ClusterName: "dev"})
-	assert.NotNil(c)
-
-	ev := event.Event{
-		PodName:       "test-pod",
-		ContainerName: "test-container",
-		Namespace:     "default",
-		Reason:        "OOMKILLED",
-		Logs:          "test\ntestlogs",
-		Events: "event1-event2-event3-event1-event2-event3-event1-event2-" +
-			"event3\nevent5\nevent6-event8-event11-event12",
-	}
-	assert.Nil(c.SendEvent(&ev))
+    teams.flowURL = server.URL
+    err := teams.SendEvent(e)
+    assert.NoError(t, err)
 }
 
-func TestInvaildHttpRequest(t *testing.T) {
-	assert := assert.New(t)
+func TestSendMessage(t *testing.T) {
+    config := map[string]interface{}{
+        "flowURL": "http://example.com",
+    }
+    appCfg := &config.App{}
+    teams := NewTeams(config, appCfg)
 
-	configMap := map[string]interface{}{
-		"webhook": "h ttp://localhost",
-	}
-	c := NewTeams(configMap, &config.App{ClusterName: "dev"})
-	assert.NotNil(c)
+    server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.WriteHeader(http.StatusOK)
+    }))
+    defer server.Close()
 
-	assert.NotNil(c.SendMessage("test"))
+    teams.flowURL = server.URL
+    err := teams.SendMessage("test message")
+    assert.NoError(t, err)
+}
 
-	configMap = map[string]interface{}{
-		"webhook": "http://localhost:132323",
-	}
-	c = NewTeams(configMap, &config.App{ClusterName: "dev"})
-	assert.NotNil(c)
+func TestSendAPI(t *testing.T) {
+    config := map[string]interface{}{
+        "flowURL": "http://example.com",
+    }
+    appCfg := &config.App{}
+    teams := NewTeams(config, appCfg)
 
-	assert.NotNil(c.SendMessage("test"))
+    payload := []byte(`{"title":"Test Title","text":"Test Text","attachment":[]}`)
+
+    server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.WriteHeader(http.StatusOK)
+    }))
+    defer server.Close()
+
+    teams.flowURL = server.URL
+    err := teams.sendAPI(payload)
+    assert.NoError(t, err)
+}
+
+func TestBuildRequestBodyTeams(t *testing.T) {
+    config := map[string]interface{}{
+        "flowURL": "http://example.com",
+        "title":   "Test Title",
+        "text":    "Test Text",
+    }
+    appCfg := &config.App{}
+    teams := NewTeams(config, appCfg)
+
+    e := &event.Event{
+        PodName:   "test-pod",
+        Namespace: "test-namespace",
+        Reason:    "test-reason",
+        Logs:      "test-logs",
+        Events:    "test-events",
+    }
+
+    payload := teams.buildRequestBodyTeams(e)
+    var result teamsFlowPayload
+    err := json.Unmarshal(payload, &result)
+    assert.NoError(t, err)
+    assert.Equal(t, "Test Title", result.Title)
+    assert.Contains(t, result.Text, "test-pod")
+    assert.Contains(t, result.Text, "test-namespace")
+    assert.Contains(t, result.Text, "test-reason")
+    assert.Contains(t, result.Text, "test-logs")
+    assert.Contains(t, result.Text, "test-events")
+}
+
+func TestBuildRequestBodyMessage(t *testing.T) {
+    config := map[string]interface{}{
+        "flowURL": "http://example.com",
+    }
+    appCfg := &config.App{}
+    teams := NewTeams(config, appCfg)
+
+    payload := teams.buildRequestBodyMessage("test message")
+    var result teamsFlowPayload
+    err := json.Unmarshal(payload, &result)
+    assert.NoError(t, err)
+    assert.Equal(t, "New Alert", result.Title)
+    assert.Equal(t, "test message", result.Text)
+    assert.Empty(t, result.Attachment)
 }


### PR DESCRIPTION
Fixes # .
- Migrated Notifications handling from Webhook to Power Automate
- Details are in this blog - https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/


**Changes proposed in this pull request: * *
- Removed Webhook-based notification system.

**Testing**
- Verified notifications are working correctly with Power Automate.

**Please review and let me know if any improvements are needed**

![teamstest](https://github.com/user-attachments/assets/f3cd4b09-e298-4ba4-b995-654577ff5254)

