### PR TITLE
fix: restore broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,7 +699,7 @@ Want to add your company? [Open an issue!](https://github.com/abahmed/kwatch/iss
 
 ## ⭐️ Stargazers
 
-<img src="https://api.star-history.com/svg?repos=abahmed/kwatch&type=Date" alt="Stargazers over time" style="max-width: 100%">
+<img src="https://star-history.dera.page/svg?repos=abahmed/kwatch&type=Date" alt="Stargazers over time" style="max-width: 100%">
 
 ## 👋 Get in touch
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the underlying GitHub stargazer API is restricted. This change points the chart to a working data source that requires no API token, so stargazers are displayed correctly again.