### PR TITLE
🧭 feat: make provider choices catalog-driven

### DIFF
--- a/cmd/providercatalog/main.go
+++ b/cmd/providercatalog/main.go
@@ -67,7 +67,7 @@ func validProviderFieldType(fieldType string) bool {
 }
 
 func providerLine(field config.ProviderField) string {
-	return strings.Join([]string{
+	parts := []string{
 		field.Provider,
 		field.DisplayName,
 		field.Field,
@@ -77,5 +77,9 @@ func providerLine(field config.ProviderField) string {
 		field.Validation,
 		field.Default,
 		field.Description,
-	}, "|")
+	}
+	if field.Group != "" || field.Condition != "" {
+		parts = append(parts, field.Group, field.Condition)
+	}
+	return strings.Join(parts, "|")
 }

--- a/deploy/provider-catalog.tsv
+++ b/deploy/provider-catalog.tsv
@@ -1,10 +1,10 @@
 # kwatch provider catalog v1
-slack|Slack|webhook|string|false|true|url||Slack webhook URL
-slack|Slack|channel|string|false|false|||Override channel
+slack|Slack|webhook|string|false|true|url||Slack webhook URL|authentication|choice:webhook
+slack|Slack|channel|string|false|false|||Override channel||required-if:authentication=token
 slack|Slack|title|string|false|false|||Custom title
 slack|Slack|text|string|false|false|||Custom text
 slack|Slack|compact|boolean|false|false|boolean|false|Single-line mode
-slack|Slack|token|string|false|true|||Bot token (xoxb-...)
+slack|Slack|token|string|false|true|||Bot token (xoxb-...)|authentication|choice:token
 discord|Discord|webhook|string|true|true|url||Discord webhook URL
 discord|Discord|title|string|false|false|||Custom title
 discord|Discord|text|string|false|false|||Custom text
@@ -143,8 +143,8 @@ ses|SES|subject|string|false|false|||Email subject
 sns|SNS|accessKeyId|string|true|true|||AWS access key ID
 sns|SNS|secretAccessKey|string|true|true|||AWS secret access key
 sns|SNS|region|string|false|false||us-east-1|AWS region (default: us-east-1)
-sns|SNS|topicArn|string|false|false|||SNS topic ARN (or targetArn)
-sns|SNS|targetArn|string|false|false|||SNS target ARN (alternative to topicArn).
+sns|SNS|topicArn|string|false|false|||SNS topic ARN (or targetArn)|destination|choice:topic
+sns|SNS|targetArn|string|false|false|||SNS target ARN (alternative to topicArn)|destination|choice:target
 sns|SNS|subject|string|false|false|||Optional subject (email subscriptions)
 jira|Jira|url|string|true|false|url||Jira base URL
 jira|Jira|user|string|true|false|||Email or username

--- a/deploy/provider-catalog.tsv
+++ b/deploy/provider-catalog.tsv
@@ -16,7 +16,7 @@ email|Email|to|string|true|false|||Receiver email
 line|LINE|token|string|true|true|||LINE Notify access token
 pagerduty|PagerDuty|integrationKey|string|true|true|||PagerDuty integration key
 telegram|Telegram|token|string|true|true|||Bot token
-telegram|Telegram|chatId|string|true|false|telegram-chat-id||Chat ID
+telegram|Telegram|chatId|string|true|false|signed-integer||Chat ID
 teams|Teams|webhook|string|true|true|url||Webhook URL
 teams|Teams|title|string|false|false|||Custom title
 teams|Teams|text|string|false|false|||Custom text

--- a/deploy/provider-catalog.tsv
+++ b/deploy/provider-catalog.tsv
@@ -56,8 +56,8 @@ pushover|Pushover|user|string|true|true|||User or group key
 pushover|Pushover|priority|integer|false|false|integer||Priority (optional)
 pushover|Pushover|title|string|false|false|||Custom title
 webex|Webex|accessToken|string|true|true|||Bot access token
-webex|Webex|roomId|string|false|false|||Room ID (optional)
-webex|Webex|toPersonEmail|string|false|false|||Person email (optional)
+webex|Webex|roomId|string|false|false|||Room ID (at least one destination required)|destination|at-least-one
+webex|Webex|toPersonEmail|string|false|false|||Person email (at least one destination required)|destination|at-least-one
 github|GitHub|token|string|true|true|||Personal access token
 github|GitHub|owner|string|true|false|||Repository owner
 github|GitHub|repo|string|true|false|||Repository name

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -207,8 +207,11 @@ monitoring, use the monitor's normal `enabled` or threshold settings.
 
 Guided notification setup uses `deploy/provider-catalog.tsv`. It covers every
 supported provider and documented provider field, and marks every credential
-field as Secret-backed. Provider credentials never appear in the general
-configuration catalog.
+field as Secret-backed. It can also describe provider-specific choice groups
+and conditional fields (for example, one authentication method requiring a
+channel). The installer interprets those relationships generically, so adding
+a new provider does not require provider-specific shell logic. Provider
+credentials never appear in the general configuration catalog.
 
 The `/kubelet` health status reports `healthy`, `partial`, `unavailable`, or
 `rbacDenied`, alongside Summary, cAdvisor, runtime, and node counts. The

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -207,11 +207,12 @@ monitoring, use the monitor's normal `enabled` or threshold settings.
 
 Guided notification setup uses `deploy/provider-catalog.tsv`. It covers every
 supported provider and documented provider field, and marks every credential
-field as Secret-backed. It can also describe provider-specific choice groups
-and conditional fields (for example, one authentication method requiring a
-channel). The installer interprets those relationships generically, so adding
-a new provider does not require provider-specific shell logic. Provider
-credentials never appear in the general configuration catalog.
+field as Secret-backed. It can also describe provider-specific choice groups,
+conditional fields, and at-least-one destination groups (for example, one
+authentication method requiring a channel). The installer interprets those
+relationships generically, so adding a new provider does not require
+provider-specific shell logic. Provider credentials never appear in the
+general configuration catalog.
 
 The `/kubelet` health status reports `healthy`, `partial`, `unavailable`, or
 `rbacDenied`, alongside Summary, cAdvisor, runtime, and node counts. The

--- a/docs/kwatch-sh.md
+++ b/docs/kwatch-sh.md
@@ -87,9 +87,9 @@ the installed release. It caches them in the cluster and falls back to its
 embedded catalogs when GitHub is not reachable. The provider catalog covers
 every supported notification provider, defines each documented prompt, and
 marks whether its value must be stored as a Secret file. It also carries
-generic choice-group and conditional-field metadata, so alternative provider
-credentials are handled from catalog data rather than provider-specific
-installer code.
+generic choice-group, conditional-field, and at-least-one destination
+metadata, so alternative provider credentials are handled from catalog data
+rather than provider-specific installer code.
 
 The release workflow generates these catalogs from Go definitions. When a new
 setting or guided provider is added, update its source definition and regenerate

--- a/docs/kwatch-sh.md
+++ b/docs/kwatch-sh.md
@@ -86,7 +86,10 @@ The manager loads the configuration, feature, and guided-provider catalogs for
 the installed release. It caches them in the cluster and falls back to its
 embedded catalogs when GitHub is not reachable. The provider catalog covers
 every supported notification provider, defines each documented prompt, and
-marks whether its value must be stored as a Secret file.
+marks whether its value must be stored as a Secret file. It also carries
+generic choice-group and conditional-field metadata, so alternative provider
+credentials are handled from catalog data rather than provider-specific
+installer code.
 
 The release workflow generates these catalogs from Go definitions. When a new
 setting or guided provider is added, update its source definition and regenerate

--- a/docs/kwatch-sh.md
+++ b/docs/kwatch-sh.md
@@ -83,8 +83,10 @@ bash -c "$(curl -fsSL https://kwatch.dev/kwatch.sh)" -- --help
 ## 🧪 Version-aware settings
 
 The manager loads the configuration, feature, and guided-provider catalogs for
-the installed release. It caches them in the cluster and falls back to its
-embedded catalogs when GitHub is not reachable. The provider catalog covers
+the installed release. It caches each catalog in the cluster and only reuses a
+cache entry when it is tagged for that exact release. There are no embedded
+catalog fallbacks in `kwatch.sh`; if the matching artifact and cache are both
+unavailable, catalog-dependent actions stop with an explicit error. The provider catalog covers
 every supported notification provider, defines each documented prompt, and
 marks whether its value must be stored as a Secret file. It also carries
 generic choice-group, conditional-field, and at-least-one destination

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -292,8 +292,8 @@ alert:
 | Parameter | What it does |
 |:---|---|
 | `alert.webex.accessToken` | 🔑 Bot access token |
-| `alert.webex.roomId` | 🚪 Room ID (optional) |
-| `alert.webex.toPersonEmail` | ✉️ Person email (optional) |
+| `alert.webex.roomId` | 🚪 Room ID (provide this or `toPersonEmail`) |
+| `alert.webex.toPersonEmail` | ✉️ Person email (provide this or `roomId`) |
 
 ### 🐙 GitHub
 

--- a/internal/config/provider_catalog.go
+++ b/internal/config/provider_catalog.go
@@ -90,9 +90,10 @@ const providerCatalogData = "" +
 	"tional)\n" +
 	"pushover|Pushover|title|string|false|false|||Custom title\n" +
 	"webex|Webex|accessToken|string|true|true|||Bot access token\n" +
-	"webex|Webex|roomId|string|false|false|||Room ID (optional)\n" +
-	"webex|Webex|toPersonEmail|string|false|false|||Person email (optiona" +
-	"l)\n" +
+	"webex|Webex|roomId|string|false|false|||Room ID (at least one " +
+	"destination required)|destination|at-least-one\n" +
+	"webex|Webex|toPersonEmail|string|false|false|||Person email (at " +
+	"least one destination required)|destination|at-least-one\n" +
 	"github|GitHub|token|string|true|true|||Personal access token\n" +
 	"github|GitHub|owner|string|true|false|||Repository owner\n" +
 	"github|GitHub|repo|string|true|false|||Repository name\n" +
@@ -742,6 +743,12 @@ func validateProviderCondition(group, condition string) error {
 	if strings.HasPrefix(condition, "choice:") {
 		if group == "" || strings.TrimPrefix(condition, "choice:") == "" {
 			return fmt.Errorf("choice conditions need a group and value")
+		}
+		return nil
+	}
+	if condition == "at-least-one" {
+		if group == "" {
+			return fmt.Errorf("at-least-one conditions need a group")
 		}
 		return nil
 	}

--- a/internal/config/provider_catalog.go
+++ b/internal/config/provider_catalog.go
@@ -45,7 +45,7 @@ const providerCatalogData = "" +
 	"pagerduty|PagerDuty|integrationKey|string|true|true|||PagerDuty inte" +
 	"gration key\n" +
 	"telegram|Telegram|token|string|true|true|||Bot token\n" +
-	"telegram|Telegram|chatId|string|true|false|telegram-chat-id||Chat ID\n" +
+	"telegram|Telegram|chatId|string|true|false|signed-integer||Chat ID\n" +
 	"teams|Teams|webhook|string|true|true|url||Webhook URL\n" +
 	"teams|Teams|title|string|false|false|||Custom title\n" +
 	"teams|Teams|text|string|false|false|||Custom text\n" +

--- a/internal/config/provider_catalog.go
+++ b/internal/config/provider_catalog.go
@@ -18,16 +18,21 @@ type ProviderField struct {
 	Validation  string
 	Default     string
 	Description string
+	Group       string
+	Condition   string
 }
 
 const providerCatalogData = "" +
-	"slack|Slack|webhook|string|false|true|url||Slack webhook URL\n" +
-	"slack|Slack|channel|string|false|false|||Override channel\n" +
+	"slack|Slack|webhook|string|false|true|url||Slack webhook URL|" +
+	"authentication|choice:webhook\n" +
+	"slack|Slack|channel|string|false|false|||Override channel||" +
+	"required-if:authentication=token\n" +
 	"slack|Slack|title|string|false|false|||Custom title\n" +
 	"slack|Slack|text|string|false|false|||Custom text\n" +
 	"slack|Slack|compact|boolean|false|false|boolean|false|Single-line mo" +
 	"de\n" +
-	"slack|Slack|token|string|false|true|||Bot token (xoxb-...)\n" +
+	"slack|Slack|token|string|false|true|||Bot token (xoxb-...)|" +
+	"authentication|choice:token\n" +
 	"discord|Discord|webhook|string|true|true|url||Discord webhook URL\n" +
 	"discord|Discord|title|string|false|false|||Custom title\n" +
 	"discord|Discord|text|string|false|false|||Custom text\n" +
@@ -194,9 +199,10 @@ const providerCatalogData = "" +
 	"sns|SNS|secretAccessKey|string|true|true|||AWS secret access key\n" +
 	"sns|SNS|region|string|false|false||us-east-1|AWS region (default: us" +
 	"-east-1)\n" +
-	"sns|SNS|topicArn|string|false|false|||SNS topic ARN (or targetArn)\n" +
-	"sns|SNS|targetArn|string|false|false|||SNS target ARN (alternative t" +
-	"o topicArn).\n" +
+	"sns|SNS|topicArn|string|false|false|||SNS topic ARN (or targetArn)|" +
+	"destination|choice:topic\n" +
+	"sns|SNS|targetArn|string|false|false|||SNS target ARN (alternative to " +
+	"topicArn)|destination|choice:target\n" +
 	"sns|SNS|subject|string|false|false|||Optional subject (email subscri" +
 	"ptions)\n" +
 	"jira|Jira|url|string|true|false|url||Jira base URL\n" +
@@ -700,8 +706,8 @@ func parseProviderCatalog(raw string) []ProviderField {
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
-		parts := strings.SplitN(line, "|", 9)
-		if len(parts) != 9 {
+		parts := strings.SplitN(line, "|", 11)
+		if len(parts) != 9 && len(parts) != 11 {
 			panic(fmt.Sprintf("invalid provider catalog row: %q", line))
 		}
 		required, err := strconv.ParseBool(parts[4])
@@ -712,13 +718,41 @@ func parseProviderCatalog(raw string) []ProviderField {
 		if err != nil {
 			panic(fmt.Sprintf("invalid provider catalog secret flag: %q", line))
 		}
+		group, condition := "", ""
+		if len(parts) == 11 {
+			group, condition = parts[9], parts[10]
+		}
+		if err := validateProviderCondition(group, condition); err != nil {
+			panic(fmt.Sprintf("invalid provider catalog condition: %q: %v", line, err))
+		}
 		fields = append(fields, ProviderField{
 			Provider: parts[0], DisplayName: parts[1], Field: parts[2],
 			Type: parts[3], Required: required, Secret: secret,
 			Validation: parts[6], Default: parts[7], Description: parts[8],
+			Group: group, Condition: condition,
 		})
 	}
 	return fields
+}
+
+func validateProviderCondition(group, condition string) error {
+	if condition == "" {
+		return nil
+	}
+	if strings.HasPrefix(condition, "choice:") {
+		if group == "" || strings.TrimPrefix(condition, "choice:") == "" {
+			return fmt.Errorf("choice conditions need a group and value")
+		}
+		return nil
+	}
+	if strings.HasPrefix(condition, "required-if:") {
+		expression := strings.TrimPrefix(condition, "required-if:")
+		if !strings.Contains(expression, "=") {
+			return fmt.Errorf("required-if conditions need group=value")
+		}
+		return nil
+	}
+	return fmt.Errorf("unsupported condition %q", condition)
 }
 
 // ProviderCatalog returns a copy of the complete guided installer schema.

--- a/internal/config/secret_refs_test.go
+++ b/internal/config/secret_refs_test.go
@@ -131,6 +131,25 @@ func TestProviderCatalogCoversKnownProviders(t *testing.T) {
 	}
 }
 
+func TestProviderCatalogDescribesConditionalCredentials(t *testing.T) {
+	fields := make(map[string]ProviderField)
+	for _, field := range ProviderCatalog() {
+		if field.Provider == "slack" || field.Provider == "sns" {
+			fields[field.Provider+"."+field.Field] = field
+		}
+	}
+
+	assert.Equal(t, "authentication", fields["slack.webhook"].Group)
+	assert.Equal(t, "choice:webhook", fields["slack.webhook"].Condition)
+	assert.Equal(
+		t,
+		"required-if:authentication=token",
+		fields["slack.channel"].Condition,
+	)
+	assert.Equal(t, "destination", fields["sns.topicArn"].Group)
+	assert.Equal(t, "choice:target", fields["sns.targetArn"].Condition)
+}
+
 func providerCatalogTestConfig(field ProviderField, value string) string {
 	parts := strings.Split(field.Field, ".")
 	var body strings.Builder

--- a/internal/config/secret_refs_test.go
+++ b/internal/config/secret_refs_test.go
@@ -134,7 +134,8 @@ func TestProviderCatalogCoversKnownProviders(t *testing.T) {
 func TestProviderCatalogDescribesConditionalCredentials(t *testing.T) {
 	fields := make(map[string]ProviderField)
 	for _, field := range ProviderCatalog() {
-		if field.Provider == "slack" || field.Provider == "sns" {
+		if field.Provider == "slack" || field.Provider == "sns" ||
+			field.Provider == "webex" {
 			fields[field.Provider+"."+field.Field] = field
 		}
 	}
@@ -148,6 +149,9 @@ func TestProviderCatalogDescribesConditionalCredentials(t *testing.T) {
 	)
 	assert.Equal(t, "destination", fields["sns.topicArn"].Group)
 	assert.Equal(t, "choice:target", fields["sns.targetArn"].Condition)
+	assert.Equal(t, "destination", fields["webex.roomId"].Group)
+	assert.Equal(t, "at-least-one", fields["webex.roomId"].Condition)
+	assert.Equal(t, "at-least-one", fields["webex.toPersonEmail"].Condition)
 }
 
 func providerCatalogTestConfig(field ProviderField, value string) string {


### PR DESCRIPTION
## What changed

- Add generic provider catalog metadata for choice groups, conditional fields, and at-least-one destination groups.
- Drive alternative credentials through catalog data instead of Slack/SNS/Webex-specific installer branches.
- Use provider-agnostic validation metadata (`signed-integer`), while accepting the legacy Telegram validator name for older release catalogs.
- Preserve compatibility with existing nine-column provider catalogs.
- Generate and ship the updated provider catalog rows.
- Document the catalog contract and add focused coverage for conditional credentials.

## Verification

- make verify (build, vet, tests, golangci-lint, formatting and line checks)
- Catalog generation comparison
- Bash 3.2 installer smoke tests for choice, required-if, at-least-one, and generic validation conditions