### PR TITLE
🧭 Fix iLert priority in the provider catalog

### DIFF
--- a/deploy/provider-catalog.tsv
+++ b/deploy/provider-catalog.tsv
@@ -104,7 +104,7 @@ clickup|ClickUp|token|string|true|true|||Personal API token
 clickup|ClickUp|listId|string|true|false|||List ID to create tasks in
 clickup|ClickUp|priority|integer|false|false|integer||Optional task priority (1-4)
 ilert|iLert|integrationKey|string|true|true|||Integration key
-ilert|iLert|priority|integer|false|false|integer||Priority (LOW/HIGH/CRITICAL, default: HIGH)
+ilert|iLert|priority|string|false|false|one-of:LOW,HIGH,CRITICAL|HIGH|Priority (LOW/HIGH/CRITICAL, default: HIGH)
 incidentio|Incident.io|url|string|true|true|url||Incident.io URL
 incidentio|Incident.io|apiKey|string|false|true|||Optional API key
 squadcast|Squadcast|serviceKey|string|true|true|||Service key

--- a/internal/config/provider_catalog.go
+++ b/internal/config/provider_catalog.go
@@ -155,7 +155,8 @@ const providerCatalogData = "" +
 	"clickup|ClickUp|priority|integer|false|false|integer||Optional task " +
 	"priority (1-4)\n" +
 	"ilert|iLert|integrationKey|string|true|true|||Integration key\n" +
-	"ilert|iLert|priority|integer|false|false|integer||Priority (LOW/HIGH" +
+	"ilert|iLert|priority|string|false|false|one-of:LOW,HIGH,CRITICAL|HIGH|" +
+	"Priority (LOW/HIGH" +
 	"/CRITICAL, default: HIGH)\n" +
 	"incidentio|Incident.io|url|string|true|true|url||Incident.io URL\n" +
 	"incidentio|Incident.io|apiKey|string|false|true|||Optional API key\n" +

--- a/internal/config/provider_catalog_test.go
+++ b/internal/config/provider_catalog_test.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProviderCatalogChoiceDefaultsAreValid(t *testing.T) {
+	for _, field := range ProviderCatalog() {
+		if !strings.HasPrefix(field.Validation, "one-of:") {
+			continue
+		}
+		allowed := strings.Split(strings.TrimPrefix(
+			field.Validation,
+			"one-of:",
+		), ",")
+		found := false
+		for _, value := range allowed {
+			if value == field.Default {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf(
+				"%s.%s default %q is not in %q",
+				field.Provider,
+				field.Field,
+				field.Default,
+				allowed,
+			)
+		}
+	}
+}
+
+func TestProviderCatalogILertPriority(t *testing.T) {
+	for _, field := range ProviderCatalog() {
+		if field.Provider != "ilert" || field.Field != "priority" {
+			continue
+		}
+		if field.Type != "string" ||
+			field.Validation != "one-of:LOW,HIGH,CRITICAL" ||
+			field.Default != "HIGH" {
+			t.Fatalf("unexpected iLert priority schema: %#v", field)
+		}
+		return
+	}
+	t.Fatal("iLert priority is missing from the provider catalog")
+}


### PR DESCRIPTION
## What changed

- describes `alert.ilert.priority` as the string value used by the provider instead of an integer
- publishes the allowed `LOW`, `HIGH`, and `CRITICAL` values plus the `HIGH` default through generic catalog metadata
- regenerates the release provider catalog
- adds coverage ensuring enumerated defaults remain valid and the iLert schema matches the provider implementation

This lets the catalog-driven `kwatch.sh` flow accept and explain valid iLert priorities without provider-specific script logic.

## Verification

- `make verify`
- `make verify-catalogs`
- `git diff --check`
